### PR TITLE
Bug-fix: Null terminate keywords array

### DIFF
--- a/audisp-json.conf
+++ b/audisp-json.conf
@@ -1,5 +1,5 @@
 mozdef_url = http://127.0.0.1:8080/events
 ssl_verify = no
 curl_verbose = no
-#curl_filelog = /var/log/audisp-json-curl.debug
+#curl_logfile = /var/log/audisp-json-curl.debug
 curl_cainfo = /etc/ssl/certs/mozilla-root.crt

--- a/json-config.c
+++ b/json-config.c
@@ -75,6 +75,7 @@ static const struct kw_pair keywords[] =
 	{"ssl_verify",	ssl_parser,	0},
 	{"curl_verbose", curl_parser,	0},
 	{"curl_logfile", curl_fparser,	0},
+	{NULL}
 };
 
 /*


### PR DESCRIPTION
The `keywords` array in json-config.c was not terminated with `NULL`
causing the loop in `kw_lookup` to go beyond the end of the array and
cause a segfault. This was discovered by uncommenting the `curl_filelog`
option in the default configuration file; the correct option is
`curl_logfile`.