### PR TITLE
s/rst/md for README add support for `file_log` which will log to file instead of HTTP/HTTPS if enabled (when set this disables any curl-based logging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-==========
-Audisp-json
-==========
-
-.. contents:: Table of contents
+# Audisp-json
 
 This program is a plugin for Linux Audit user space programs available at <http://people.redhat.com/sgrubb/audit/>.
 It uses the audisp multiplexer.
@@ -17,8 +13,7 @@ Regular audit log messages and audisp-json error, info messages still use syslog
 Due to the ring buffer filling up when the front-end HTTP server does not process fast enough, the program may slowly
 grow in memory for a while on busy systems. It'll stop at 512 messages (hard-coded) buffered.
 
-Building
---------
+## Building
 
 Required dependencies:
 - Audit (2.0+)
@@ -29,8 +24,7 @@ For package building:
 - FPM
 - rpmbuild (rpm)
 
-Build targets:
-=============
+### Build targets:
 They're self explanatory.
 
 - make
@@ -40,64 +34,57 @@ They're self explanatory.
 - make uninstall
 - make clean
 
-Mozilla build targets
-=====================
+### Mozilla build targets
 We previously used audisp-cef, so we would want to mark that package as obsolete.
 
 - make rpm FPMOPTS="--replaces audisp-cef"
 - make deb FPMOPTS="--replaces audisp-cef"
 
-Deal with auditd quirks, or how to make auditd useable in prod
---------------------------------------------------------------
+## Deal with auditd quirks, or how to make auditd useable in prod
 
 These examples filter out messages that may clutter your log or/and DOS yourself (high I/O) if auditd goes
 down for any reason.
 
-Example for rsyslog
-===================
+### Example for rsyslog
 
- ::
-
+```
     #Drop native audit messages from the kernel (may happen is auditd dies, and may kill the system otherwise)
     :msg, regex, "type=[0-9]* audit" ~
     #Drop audit sid msg (work-around until RH fixes the kernel - should be fixed in RHEL7 and recent RHEL6)
     :msg, contains, "error converting sid to string" ~
+```
 
+### Example for syslog-ng
 
-Example for syslog-ng
-=====================
-
- ::
-
+```
     source s_syslog { unix-dgram("/dev/log"); };
     filter f_not_auditd { not message("type=[0-9]* audit") or not message("error converting sid to string"); };
     log{ source(s_syslog);f ilter(f_not_auditd); destination(d_logserver); };
+```
 
-Misc other things to do
-=======================
+### Misc other things to do
 
-- It is suggested to bump the audispd queue to adjust for extremely busy systems, for ex. q_depth=512.
-- You will also probably need to bump the kernel-side buffer and change the rate limit in audit.rules, for ex. -b 16384
-  -r 500.
+- It is suggested to bump the audispd queue to adjust for extremely busy systems, for ex. `q_depth=512`.
+- You will also probably need to bump the kernel-side buffer and change the rate limit in audit.rules, for ex. `-b 16384
+  -r 500`.
 
-Message handling
-----------------
+## Message handling
 
 Syscalls are interpreted by audisp-json and transformed into a MozDef JSON message.
 This means, for example, all execve() and related calls will be aggregated into a message of type EXECVE.
 
-.. note: MozDef messages are not sent to syslog. They're sent to MozDef directly.
+NOTE: MozDef messages are not sent to syslog. They're sent to MozDef directly.
 
 Supported messages are listed in the document messages_format.rst
 
-Configuration file
-==================
+## Configuration file
 
-The audisp-json.conf file has 4 options:
+The audisp-json.conf file has a few options:
 
-:mozdef_url: Any server supporting JSON MozDef messages
-:ssl_verify: Yes or no. Only use no for testing purposes.
-:curl_verbose: Enables curl verbose mode for debugging. start audisp-json in the foreground to see messages.
-:curl_logfile: Path to a file to log curl debug messages to. Most useful with curl_verbose also set. Otherwise, message
-               go to stderr.
-:curl_cainfo: Specify the path to a single CA certificate, if needed. When not specified, system's CA bundle is used.
+- `mozdef_url` Any server supporting JSON MozDef messages
+- `ssl_verify` Yes or no. Only use no for testing purposes.
+- `curl_verbose` Enables curl verbose mode for debugging. start audisp-json in the foreground to see messages.
+- `curl_logfile` Path to a file to log curl debug messages to. Most useful with curl_verbose also set. Otherwise,
+  message go to stderr.
+- `curl_cainfo` Specify the path to a single CA certificate, if needed. When not specified, system's CA bundle is used.
+- `file_log` Specify a file path to log the json data to. This disables mozdef logging.

--- a/audisp-json.conf
+++ b/audisp-json.conf
@@ -1,5 +1,6 @@
 mozdef_url = http://127.0.0.1:8080/events
 ssl_verify = no
 curl_verbose = no
-#curl_filelog = /var/log/audisp-json-curl.debug
+#curl_logfile = /var/log/audisp-json-curl.debug
 curl_cainfo = /etc/ssl/certs/mozilla-root.crt
+file_log = audisp-json.log

--- a/json-config.c
+++ b/json-config.c
@@ -67,6 +67,8 @@ static int curl_parser(struct nv_pair *nv, int line,
 		json_conf_t *config);
 static int curl_fparser(struct nv_pair *nv, int line,
 		json_conf_t *config);
+static int file_fparser(struct nv_pair *nv, int line,
+		json_conf_t *config);
 
 static const struct kw_pair keywords[] =
 {
@@ -75,6 +77,7 @@ static const struct kw_pair keywords[] =
 	{"ssl_verify",	ssl_parser,	0},
 	{"curl_verbose", curl_parser,	0},
 	{"curl_logfile", curl_fparser,	0},
+	{"file_log", file_fparser,	0},
 };
 
 /*
@@ -327,6 +330,16 @@ static int curl_fparser(struct nv_pair *nv, int line,
 		config->curl_logfile = strdup(nv->value);
 	else
 		config->curl_logfile = NULL;
+	return 0;
+}
+
+static int file_fparser(struct nv_pair *nv, int line,
+		json_conf_t *config)
+{
+	if (nv->value)
+		config->file_log = strdup(nv->value);
+	else
+		config->file_log = NULL;
 	return 0;
 }
 

--- a/json-config.h
+++ b/json-config.h
@@ -31,6 +31,7 @@ typedef struct json_conf
 	const char *mozdef_url;
 	const char *curl_cainfo;
 	const char *curl_logfile;
+        const char *file_log;
 	int ssl_verify;
 	int curl_verbose;
 } json_conf_t;


### PR DESCRIPTION
NOTE: The messages are not comma-separated, they're blocks of valid JSON
after block of valid JSON